### PR TITLE
Added asCmd extension for small command declarations to tackle charlimit

### DIFF
--- a/src/main/kotlin/at/helpch/hccce/Cmd.kt
+++ b/src/main/kotlin/at/helpch/hccce/Cmd.kt
@@ -1,0 +1,15 @@
+package at.helpch.hccce
+
+import org.bukkit.Bukkit
+import org.bukkit.command.CommandSender
+
+// Yugi Start
+
+/**
+ * Smaller command declaration since we only have 250 chars per commit
+ */
+fun String.asCmd(execute: (CommandSender, Array<out String>) -> Boolean) {
+    Bukkit.getPluginCommand(this)?.setExecutor { sender, _, _, args -> execute(sender, args); }
+}
+
+// Yugi End


### PR DESCRIPTION
Extension function String.asCmd added for smaller command declarations since we have a commit limit of 250 chars